### PR TITLE
Add flags to tweak output

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ npx swagger2llm https://example.com/swagger.json
 npx swagger2llm --multiple https://example.com/openapi.yaml
 ```
 
+Flags `--no-examples` and `--no-llm` can be used to remove example blocks from
+the specification and to disable shortening via the OpenAI API respectively.
+
 When `--multiple` is used, files `llms-level1.txt`, `llms-level2.txt` and `llms-level3.txt` are placed in the `llms` directory. Without it a single `llms.txt` with the most details is created in the current directory.
 
 Set `OPENAI_API_KEY` to let the tool shorten very long texts via the OpenAI API.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,28 +1,34 @@
 #!/usr/bin/env node
 import minimist from 'minimist';
 import { promises as fs } from 'fs';
-import { downloadSpec, generateSummary } from './index.js';
+import { downloadSpec, generateSummary, stripExamples } from './index.js';
 
 async function main() {
-  const args = minimist(process.argv.slice(2), { boolean: ['multiple'], alias: { m: 'multiple' } });
+  const args = minimist(process.argv.slice(2), {
+    boolean: ['multiple', 'no-examples', 'no-llm'],
+    alias: { m: 'multiple' }
+  });
   const url = args._[0];
   if (!url) {
-    console.error('Usage: swagger2llm [--multiple] <url>');
+    console.error('Usage: swagger2llm [--multiple] [--no-examples] [--no-llm] <url>');
     process.exit(1);
   }
   console.log(`Downloading spec from ${url}`);
   const spec = await downloadSpec(url);
+  if (args['no-examples']) {
+    stripExamples(spec);
+  }
   console.log(`Spec downloaded`);
   if (args.multiple) {
     const dir = 'llms';
     await fs.mkdir(dir, { recursive: true });
     for (const l of [1, 2, 3]) {
-      const content = await generateSummary(spec, l);
+      const content = await generateSummary(spec, l, { useLlm: !args['no-llm'] });
       await fs.writeFile(`${dir}/llms-level${l}.txt`, content, 'utf8');
       console.log(`llms-level${l}.txt generated`);
     }
   } else {
-    const content = await generateSummary(spec, 3);
+    const content = await generateSummary(spec, 3, { useLlm: !args['no-llm'] });
     await fs.writeFile('llms.txt', content, 'utf8');
     console.log(`llms.txt generated`);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,8 +86,8 @@ function truncate(text: string, max = 120): string {
   return text.length > max ? text.slice(0, max - 3) + '...' : text;
 }
 
-async function maybeShorten(text: string): Promise<string> {
-  if (text.length <= 300 || !process.env.OPENAI_API_KEY) {
+async function maybeShorten(text: string, useLlm: boolean): Promise<string> {
+  if (!useLlm || text.length <= 300 || !process.env.OPENAI_API_KEY) {
     return truncate(text);
   }
   const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
@@ -102,20 +102,35 @@ async function maybeShorten(text: string): Promise<string> {
   return truncate(completion.choices[0].message.content || text);
 }
 
-export async function generateSummary(spec: any, level = 3): Promise<string> {
+export function stripExamples(obj: any): void {
+  if (Array.isArray(obj)) {
+    obj.forEach(stripExamples);
+  } else if (obj && typeof obj === 'object') {
+    for (const key of Object.keys(obj)) {
+      if (key === 'examples') {
+        delete obj[key];
+      } else {
+        stripExamples(obj[key]);
+      }
+    }
+  }
+}
+
+export async function generateSummary(spec: any, level = 3, options: { useLlm?: boolean } = {}): Promise<string> {
   if (level >= 3) {
     return JSON.stringify(spec, null, 2);
   }
   const lines: string[] = [];
   const paths = spec.paths || {};
   for (const [path, methods] of Object.entries<any>(paths)) {
+    if (lines.length > 0) lines.push('');
     for (const [method, details] of Object.entries<any>(methods)) {
       let line = `${method.toUpperCase()} ${path}`;
       if (details.summary) {
-        line += ` - ${await maybeShorten(details.summary)}`;
+        line += ` - ${await maybeShorten(details.summary, options.useLlm !== false)}`;
       }
       if (details.description) {
-        const desc = await maybeShorten(details.description);
+        const desc = await maybeShorten(details.description, options.useLlm !== false);
         line += `: ${desc}`;
       }
       lines.push(line);
@@ -125,7 +140,7 @@ export async function generateSummary(spec: any, level = 3): Promise<string> {
           if (p.in) pLine += ` (${p.in})`;
           if (p.required) pLine += ' required';
           if (p.description) {
-            pLine += ` - ${await maybeShorten(p.description)}`;
+            pLine += ` - ${await maybeShorten(p.description, options.useLlm !== false)}`;
           }
           lines.push(pLine);
         }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,4 @@
-import { generateSummary } from '../src/index';
+import { generateSummary, stripExamples } from '../src/index';
 import { describe, it, expect } from 'vitest';
 
 const spec = {
@@ -10,12 +10,16 @@ const spec = {
         description: 'Return a list of users',
         parameters: [
           { name: 'page', in: 'query', description: 'Page number', required: false }
-        ]
+        ],
+        examples: { a: { foo: 'bar' } }
       },
       post: {
         summary: 'Create user',
         description: 'Add a new user'
       }
+    },
+    '/posts': {
+      get: { summary: 'List posts', description: 'Return posts' }
     }
   }
 };
@@ -24,14 +28,38 @@ describe('generateSummary', () => {
   it('level 1 includes descriptions', async () => {
     const result = await generateSummary(spec, 1);
     expect(result.trim()).toBe(
-      'GET /users - List users: Return a list of users\nPOST /users - Create user: Add a new user'
+      [
+        'GET /users - List users: Return a list of users',
+        'POST /users - Create user: Add a new user',
+        '',
+        'GET /posts - List posts: Return posts'
+      ].join('\n')
     );
   });
 
   it('level 2 adds parameters', async () => {
     const result = await generateSummary(spec, 2);
     expect(result.trim()).toBe(
-      'GET /users - List users: Return a list of users\n  param page (query) - Page number\nPOST /users - Create user: Add a new user'
+      [
+        'GET /users - List users: Return a list of users',
+        '  param page (query) - Page number',
+        'POST /users - Create user: Add a new user',
+        '',
+        'GET /posts - List posts: Return posts'
+      ].join('\n')
     );
+  });
+
+  it('stripExamples removes examples', () => {
+    const copy: any = JSON.parse(JSON.stringify(spec));
+    stripExamples(copy);
+    expect(copy.paths['/users'].get.examples).toBeUndefined();
+  });
+
+  it('no llm just truncates long text', async () => {
+    const longDesc = 'x'.repeat(400);
+    const longSpec = { paths: { '/long': { get: { description: longDesc } } } };
+    const result = await generateSummary(longSpec, 1, { useLlm: false });
+    expect(result.trim().length).toBeLessThanOrEqual(120 + 'GET /long: '.length);
   });
 });


### PR DESCRIPTION
## Summary
- add `--no-examples` flag to strip `examples` sections
- add `--no-llm` to skip OpenAI shortening
- insert empty line between path groups
- extend tests and docs

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6848b3aabc78832cb7185e83bd1c72f3